### PR TITLE
Fixed typos with OAuth2 example

### DIFF
--- a/src/partials/document/oauth2.html.md
+++ b/src/partials/document/oauth2.html.md
@@ -47,6 +47,7 @@ app.get('/oauth2/callback', function(req, res) {
     console.log("User ID: " + userInfo.id);
     console.log("Org ID: " + userInfo.organizationId);
     // ...
+    res.send('success'); // or your desired response
   });
 });
 ```

--- a/src/partials/document/oauth2.html.md
+++ b/src/partials/document/oauth2.html.md
@@ -11,7 +11,7 @@ var jsforce = require('jsforce');
 //
 // OAuth2 client information can be shared with multiple connections.
 //
-var oauth2 = new sf.OAuth2({
+var oauth2 = new jsforce.OAuth2({
   // you can change loginUrl to connect to sandbox or prerelease env.
   // loginUrl : 'https://test.salesforce.com',
   clientId : '<your Salesforce OAuth2 client ID is here>',
@@ -35,7 +35,7 @@ After the acceptance of authorization request, your app is callbacked from Sales
 // Pass received authz code and get access token
 //
 app.get('/oauth2/callback', function(req, res) {
-  var conn = new sf.Connection({ oauth2 : oauth2 });
+  var conn = new jsforce.Connection({ oauth2 : oauth2 });
   var code = req.param('code');
   conn.authorize(code, function(err, userInfo) {
     if (err) { return console.error(err); }


### PR DESCRIPTION
Re-created pull request from https://github.com/jsforce/jsforce.github.io/pull/13/files based on your comment that the documentation source is the `jsforce-website` project.