### PR TITLE
Add information on security token usage

### DIFF
--- a/src/partials/document/connection.html.md
+++ b/src/partials/document/connection.html.md
@@ -31,7 +31,7 @@ conn.login(username, password, function(err, userInfo) {
 
 ### Username and Password Login (OAuth2 Resource Owner Password Credential)
 
-When OAuth2 client information is given, `Connection#login(username, password)` uses OAuth2 Resource Owner Password Credential flow to login to Salesforce.
+When OAuth2 client information is given, `Connection#login(username, password + security_token)` uses OAuth2 Resource Owner Password Credential flow to login to Salesforce.
 
 ```javascript
 var jsforce = require('jsforce');


### PR DESCRIPTION
Showing the reader exactly how to use the security token
is beneficial to the documentation. This removes the guess work that 
the reader might have to employ.